### PR TITLE
autostart .desktop file takes into account RUN_MODE - ref #91

### DIFF
--- a/App/globals.h
+++ b/App/globals.h
@@ -8,6 +8,7 @@ namespace Lb {
     namespace Globals {
         extern QString tasksDirectory;
         extern QString applicationName;
+        extern QString autoStartFilename;
     }
 }
 

--- a/App/main.cpp
+++ b/App/main.cpp
@@ -21,6 +21,7 @@ namespace Lb {
     namespace Globals {
         QString tasksDirectory = RUN_MODE == "DEV" ? QString("%1/.lbackup-dev").arg(homeDirectory()) : QString("%1/.lbackup").arg(homeDirectory());
         QString applicationName = RUN_MODE == "DEV" ? "Lisa Backup DEV" : "Lisa Backup";
+        QString autoStartFilename = RUN_MODE == "DEV" ? "lisa-backup-dev.desktop" : "lisa-backup.desktop"; // name of autostart file created under ~/.config/autostart
     }
 }
 

--- a/App/utils.cpp
+++ b/App/utils.cpp
@@ -59,7 +59,7 @@ QString lbLauncherScriptBinaryPath()
 
 QString autoStartDesktopFilePath()
 {
-    return QString("%1/.config/autostart/lisa-backup.desktop").arg(homeDirectory());
+    return QString("%1/.config/autostart/%2").arg(homeDirectory()).arg(Lb::Globals::autoStartFilename);
 }
 
 // /home/{username}/.lbackup


### PR DESCRIPTION
A different .desktop autostart file is created according to RUN_MODE setting. This make it cleaner using LisaBackup and also developing it.